### PR TITLE
Add support for metadata references

### DIFF
--- a/src/aind_slims_api/models/__init__.py
+++ b/src/aind_slims_api/models/__init__.py
@@ -10,6 +10,7 @@ from aind_slims_api.models.unit import SlimsUnit
 from aind_slims_api.models.user import SlimsUser
 from aind_slims_api.models.waterlog_result import SlimsWaterlogResult
 from aind_slims_api.models.waterlog_water_restriction import SlimsWaterRestrictionEvent
+from aind_slims_api.models.metadata import SlimsMetadataReference
 
 __all__ = [
     "SlimsAttachment",
@@ -20,4 +21,5 @@ __all__ = [
     "SlimsUser",
     "SlimsWaterlogResult",
     "SlimsWaterRestrictionEvent",
+    "SlimsMetadataReference",
 ]

--- a/src/aind_slims_api/models/metadata.py
+++ b/src/aind_slims_api/models/metadata.py
@@ -1,0 +1,37 @@
+from pydantic import Field
+from typing import Optional
+from aind_slims_api.models.base import SlimsBaseModel
+
+
+class SlimsMetadataReference(SlimsBaseModel):
+    """Model for an instance of the metadata reference in SLIMS. Metadata
+     content is added to metadata references in the form of attachments.
+
+    Examples
+    --------
+    >>> from aind_slims_api import SlimsClient
+    >>> from aind_slims_api import models
+    >>> client = SlimsClient()
+
+    ### Read
+    >>> metadata_reference = client.fetch_model(
+    ...  models.SlimsMetadataReference,
+    ...  name="323_EPHYS1_OPTO_20240212"
+    ... )
+    >>> attachments = client.fetch_attachments(metadata_reference)
+    >>> metadata = client.fetch_attachment_content(attachments[0])
+    >>> metadata.json()["rig_id"]
+    '323_EPHYS1_OPTO_2024-02-12'
+
+    ### Write
+    >>> import json
+    >>> attachment_pk = client.add_attachment_content(
+    ...  metadata_reference,
+    ...  "test_metadata_attachment_name",
+    ...  json.dumps({"rig_id": "323_EPHYS1_OPTO_2024-02-12"})
+    ... )
+    """
+
+    name: str = Field(..., alias="rdrc_name")
+    pk: Optional[int] = Field(None, alias="rdrc_pk")
+    _slims_table = "ReferenceDataRecord"

--- a/src/aind_slims_api/types.py
+++ b/src/aind_slims_api/types.py
@@ -11,6 +11,7 @@ SLIMS_TABLES = Literal[
     "ContentEvent",
     "Unit",
     "Result",
+    "ReferenceDataRecord",
     "Test",
     "User",
     "Groups",


### PR DESCRIPTION
Rig metadata is currently being stored as attachments for ReferenceDataRecords, this pr adds this functionality.