### PR TITLE
adding pydantic 2.7 to requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     'slims-python-api',
-    'pydantic',
+    'pydantic>=2.7',
     'pydantic-settings'
 ]
 


### PR DESCRIPTION
I was having issues using the aind-slims-api using a pydantic version < 2.7 due to [this issue ](https://github.com/pydantic/pydantic/pull/9001). I updated the requirement to reflect this versioning need. 