### PR TITLE
Instrument Rdrc

### DIFF
--- a/src/aind_slims_api/models/__init__.py
+++ b/src/aind_slims_api/models/__init__.py
@@ -4,7 +4,7 @@
 
 from aind_slims_api.models.attachment import SlimsAttachment
 from aind_slims_api.models.behavior_session import SlimsBehaviorSession
-from aind_slims_api.models.instrument import SlimsInstrument
+from aind_slims_api.models.instrument import SlimsInstrument, SlimsInstrumentRdrc
 from aind_slims_api.models.metadata import SlimsMetadataReference
 from aind_slims_api.models.mouse import SlimsMouseContent
 from aind_slims_api.models.unit import SlimsUnit
@@ -16,6 +16,7 @@ __all__ = [
     "SlimsAttachment",
     "SlimsBehaviorSession",
     "SlimsInstrument",
+    "SlimsInstrumentRdrc",
     "SlimsMouseContent",
     "SlimsUnit",
     "SlimsUser",

--- a/src/aind_slims_api/models/ecephys_session.py
+++ b/src/aind_slims_api/models/ecephys_session.py
@@ -180,8 +180,8 @@ class SlimsStimulusEpochsResult(SlimsBaseModel):
     )
     stimulus_name: Optional[str] = Field(
         default=None,
-        serialization_alias="rslt_cf_stimulusDeviceNames",
-        validation_alias="rslt_cf_stimulusDeviceNames",
+        serialization_alias="rslt_cf_stimulusName",
+        validation_alias="rslt_cf_stimulusName",
     )
     stimulus_modalities: Optional[List] = Field(
         default=None,
@@ -375,26 +375,6 @@ class SlimsEphysInsertionResult(SlimsBaseModel):
     _slims_table = "Result"
     _base_fetch_filters: ClassVar[dict[str, str]] = {
         "test_name": "test_ephys_insertion",
-    }
-
-
-class SlimsInstrumentRdrc(SlimsBaseModel):
-    """Model for Instrument Rdrc"""
-
-    pk: Optional[int] = Field(
-        default=None, serialization_alias="rdrc_pk", validation_alias="rdrc_pk"
-    )
-    name: Optional[str] = Field(
-        default=None, serialization_alias="rdrc_name", validation_alias="rdrc_name"
-    )
-    created_on: Optional[datetime] = Field(
-        default=None,
-        serialization_alias="rdrc_createdOn",
-        validation_alias="rdrc_createdOn",
-    )
-    _slims_table = "ReferenceDataRecord"
-    _base_fetch_filters: ClassVar[dict[str, str]] = {
-        "rdty_name": "AIND Instruments",
     }
 
 

--- a/src/aind_slims_api/models/instrument.py
+++ b/src/aind_slims_api/models/instrument.py
@@ -1,13 +1,34 @@
 """Contains a model for the instrument content, and a method for fetching it"""
 
 from datetime import datetime
-from typing import Optional
+from typing import Optional, ClassVar
 
 from pydantic import Field
 
 from aind_slims_api.models.base import SlimsBaseModel
 
 
+class SlimsInstrumentRdrc(SlimsBaseModel):
+    """Model for Instrument Rdrc"""
+
+    pk: Optional[int] = Field(
+        default=None, serialization_alias="rdrc_pk", validation_alias="rdrc_pk"
+    )
+    name: Optional[str] = Field(
+        default=None, serialization_alias="rdrc_name", validation_alias="rdrc_name"
+    )
+    created_on: Optional[datetime] = Field(
+        default=None,
+        serialization_alias="rdrc_createdOn",
+        validation_alias="rdrc_createdOn",
+    )
+    _slims_table = "ReferenceDataRecord"
+    _base_fetch_filters: ClassVar[dict[str, str]] = {
+        "rdty_name": "AIND Instruments",
+    }
+
+
+# Slims Instrument model may be deprecated. New Instruments are stored in RDRC table
 class SlimsInstrument(SlimsBaseModel):
     """Model for a SLIMS instrument record.
 

--- a/src/aind_slims_api/models/instrument.py
+++ b/src/aind_slims_api/models/instrument.py
@@ -28,10 +28,9 @@ class SlimsInstrumentRdrc(SlimsBaseModel):
     }
 
 
-# Slims Instrument model may be deprecated. New Instruments are stored in RDRC table
 class SlimsInstrument(SlimsBaseModel):
     """Model for a SLIMS instrument record.
-
+    This model may be deprecated. Use SlimsInstrumentRdrc for newer instruments.
     Examples
     --------
     >>> from aind_slims_api.core import SlimsClient

--- a/src/aind_slims_api/operations/ecephys_session.py
+++ b/src/aind_slims_api/operations/ecephys_session.py
@@ -21,8 +21,8 @@ from aind_slims_api.models.ecephys_session import (
     SlimsGroupOfSessionsRunStep,
     SlimsMouseSessionRunStep,
     SlimsBrainStructureRdrc,
-    SlimsInstrumentRdrc,
 )
+from aind_slims_api.models import SlimsInstrumentRdrc
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_operations/test_ecephys_session.py
+++ b/tests/test_operations/test_ecephys_session.py
@@ -19,8 +19,8 @@ from aind_slims_api.models.ecephys_session import (
     SlimsExperimentRunStepContent,
     SlimsExperimentRunStep,
     SlimsBrainStructureRdrc,
-    SlimsInstrumentRdrc,
 )
+from aind_slims_api.models.instrument import SlimsInstrumentRdrc
 from aind_slims_api.operations import EcephysSession, fetch_ecephys_sessions
 from aind_slims_api.operations.ecephys_session import EcephysSessionBuilder
 


### PR DESCRIPTION
closes #49 

- Moves model for Instrument in Rdrc table to instrument.py because instruments are being stored there
- Hot fix: fixes stimulus_name mapping