### PR TITLE
Fix: Get Reagent Info

### DIFF
--- a/src/aind_slims_api/__init__.py
+++ b/src/aind_slims_api/__init__.py
@@ -1,6 +1,6 @@
 """Init package"""
 
-__version__ = "0.1.18"
+__version__ = "0.1.19"
 
 from aind_slims_api.configuration import AindSlimsApiSettings
 

--- a/src/aind_slims_api/models/experiment_run_step.py
+++ b/src/aind_slims_api/models/experiment_run_step.py
@@ -153,7 +153,7 @@ class SlimsWashRunStep(SlimsExperimentRunStep):
         serialization_alias="xprs_cf_spimWashType",
         validation_alias="xprs_cf_spimWashType",
     )  # FIXED CHOICE
-    reagent_pk: Optional[int] = Field(
+    reagent_pk: Optional[list[int]] = Field(
         None,
         serialization_alias="xprs_cf_fk_reagent_multiselect",
         validation_alias="xprs_cf_fk_reagent_multiselect",

--- a/src/aind_slims_api/models/experiment_run_step.py
+++ b/src/aind_slims_api/models/experiment_run_step.py
@@ -155,8 +155,8 @@ class SlimsWashRunStep(SlimsExperimentRunStep):
     )  # FIXED CHOICE
     reagent_pk: Optional[int] = Field(
         None,
-        serialization_alias="xprs_cf_fk_reagent",
-        validation_alias="xprs_cf_fk_reagent",
+        serialization_alias="xprs_cf_fk_reagent_multiselect",
+        validation_alias="xprs_cf_fk_reagent_multiselect",
     )
     start_time: Optional[datetime] = Field(
         None,

--- a/src/aind_slims_api/models/histology.py
+++ b/src/aind_slims_api/models/histology.py
@@ -1,7 +1,7 @@
 """Contains models for a histology result stored in SLIMS."""
 
 from datetime import datetime
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, Any
 
 from pydantic import Field
 
@@ -89,7 +89,6 @@ class SlimsReagentContent(SlimsBaseModel):
         serialization_alias="cntn_cf_lotNumber",
         validation_alias="cntn_cf_lotNumber",
     )
-    # TODO: is reagent name the ref number name? if so we'll need to add API call to rdrc table for it
     reagent_ref_pk: Optional[int] = Field(
         None,
         serialization_alias="cntn_cf_fk_reagentCatalogNumber",
@@ -119,6 +118,32 @@ class SlimsSource(SlimsBaseModel):
     )
     _slims_table = "Source"
 
+class SlimsReagentDetailsRdrc(SlimsBaseModel):
+    """Model for a Reagent Catalog Reference Data Record"""
+    pk: Optional[int] = Field(
+        None, serialization_alias="rdrc_pk", validation_alias="rdrc_pk"
+    )
+    name: Optional[str] = Field(
+        None, serialization_alias="rdrc_name", validation_alias="rdrc_name"
+    )
+    manufacturer_pk: Optional[int] = Field(
+        None,
+        serialization_alias="rdrc_cf_fk_manufacturer",
+        validation_alias="rdrc_cf_fk_manufacturer"
+    )
+    created_on: Optional[datetime] = Field(
+        None,
+        serialization_alias="rdrc_createdOn",
+        validation_alias="rdrc_createdOn",
+    )
+    _slims_table = "ReferenceDataRecord"
+    _base_fetch_filters: ClassVar[dict[str, Any]] = {
+        "rdty_name": [
+            "External reagent details",
+            "Reagent Details",
+            "Internally Produced Reagent Details"
+        ]
+    }
 
 class SlimsProtocolSOP(SlimsBaseModel):
     """Model for Protocols SOP"""

--- a/src/aind_slims_api/models/histology.py
+++ b/src/aind_slims_api/models/histology.py
@@ -89,10 +89,11 @@ class SlimsReagentContent(SlimsBaseModel):
         serialization_alias="cntn_cf_lotNumber",
         validation_alias="cntn_cf_lotNumber",
     )
-    reagent_name: Optional[str] = Field(
+    # TODO: is reagent name the ref number name? if so we'll need to add API call to rdrc table for it
+    reagent_ref_pk: Optional[int] = Field(
         None,
-        serialization_alias="cntn_cf_reagentName",
-        validation_alias="cntn_cf_reagentName",
+        serialization_alias="cntn_cf_fk_reagentCatalogNumber",
+        validation_alias="cntn_cf_fk_reagentCatalogNumber"
     )
     source_pk: Optional[int] = Field(
         None, serialization_alias="cntn_fk_source", validation_alias="cntn_fk_source"

--- a/src/aind_slims_api/models/histology.py
+++ b/src/aind_slims_api/models/histology.py
@@ -98,9 +98,6 @@ class SlimsReagentContent(SlimsBaseModel):
         None, serialization_alias="cntn_fk_source", validation_alias="cntn_fk_source"
     )
     _slims_table = "Content"
-    _base_fetch_filters: ClassVar[dict[str, str]] = {
-        "cntp_name": "EasyIndex",
-    }
 
 
 class SlimsSource(SlimsBaseModel):

--- a/src/aind_slims_api/models/histology.py
+++ b/src/aind_slims_api/models/histology.py
@@ -1,7 +1,7 @@
 """Contains models for a histology result stored in SLIMS."""
 
 from datetime import datetime
-from typing import ClassVar, Optional, Any
+from typing import Any, ClassVar, Optional
 
 from pydantic import Field
 
@@ -92,7 +92,7 @@ class SlimsReagentContent(SlimsBaseModel):
     reagent_ref_pk: Optional[int] = Field(
         None,
         serialization_alias="cntn_cf_fk_reagentCatalogNumber",
-        validation_alias="cntn_cf_fk_reagentCatalogNumber"
+        validation_alias="cntn_cf_fk_reagentCatalogNumber",
     )
     source_pk: Optional[int] = Field(
         None, serialization_alias="cntn_fk_source", validation_alias="cntn_fk_source"
@@ -118,8 +118,10 @@ class SlimsSource(SlimsBaseModel):
     )
     _slims_table = "Source"
 
+
 class SlimsReagentDetailsRdrc(SlimsBaseModel):
     """Model for a Reagent Catalog Reference Data Record"""
+
     pk: Optional[int] = Field(
         None, serialization_alias="rdrc_pk", validation_alias="rdrc_pk"
     )
@@ -129,7 +131,7 @@ class SlimsReagentDetailsRdrc(SlimsBaseModel):
     manufacturer_pk: Optional[int] = Field(
         None,
         serialization_alias="rdrc_cf_fk_manufacturer",
-        validation_alias="rdrc_cf_fk_manufacturer"
+        validation_alias="rdrc_cf_fk_manufacturer",
     )
     created_on: Optional[datetime] = Field(
         None,
@@ -141,9 +143,10 @@ class SlimsReagentDetailsRdrc(SlimsBaseModel):
         "rdty_name": [
             "External reagent details",
             "Reagent Details",
-            "Internally Produced Reagent Details"
+            "Internally Produced Reagent Details",
         ]
     }
+
 
 class SlimsProtocolSOP(SlimsBaseModel):
     """Model for Protocols SOP"""

--- a/src/aind_slims_api/operations/ecephys_session.py
+++ b/src/aind_slims_api/operations/ecephys_session.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from aind_slims_api import SlimsClient
 from aind_slims_api.exceptions import SlimsRecordNotFound
-from aind_slims_api.models import SlimsInstrumentRdrc
+from aind_slims_api.models import SlimsInstrumentRdrc, SlimsMouseContent
 from aind_slims_api.models.ecephys_session import (
     SlimsBrainStructureRdrc,
     SlimsDomeModuleRdrc,
@@ -25,7 +25,6 @@ from aind_slims_api.models.experiment_run_step import (
     SlimsGroupOfSessionsRunStep,
     SlimsMouseSessionRunStep,
 )
-from aind_slims_api.models import SlimsMouseContent
 
 logger = logging.getLogger(__name__)
 

--- a/src/aind_slims_api/operations/histology_procedures.py
+++ b/src/aind_slims_api/operations/histology_procedures.py
@@ -65,8 +65,8 @@ def fetch_reagents(client: SlimsClient, reagent_pks: List[int]) -> List[SlimsRea
         )
         reagents.append(
             SlimsReagent(
-                reagent_content=reagent_content,
-                reagent_details=details,
+                content=reagent_content,
+                details=details,
                 source=source,
             )
         )

--- a/src/aind_slims_api/operations/histology_procedures.py
+++ b/src/aind_slims_api/operations/histology_procedures.py
@@ -26,7 +26,7 @@ class SlimsWash(BaseModel):
     """Pydantic model to store Specimen Procedure Info"""
 
     wash_step: Optional[SlimsWashRunStep] = None
-    reagents: Optional[List[Tuple[SlimsReagentContent, SlimsSource]]] = []
+    reagents: List[Tuple[SlimsReagentContent, Optional[SlimsSource]]] = []
 
 
 class SPIMHistologyExpBlock(BaseModel):

--- a/src/aind_slims_api/operations/histology_procedures.py
+++ b/src/aind_slims_api/operations/histology_procedures.py
@@ -38,7 +38,7 @@ class SPIMHistologyExpBlock(BaseModel):
 
 
 def fetch_washes(client: SlimsClient, experimentrun_pk: int) -> List[SlimsWash]:
-    """Fetches washes for a given experimentrun_pk"""
+    """Fetches washes for a given experimentrun_pk."""
     wash_run_steps = client.fetch_models(
         SlimsWashRunStep, experimentrun_pk=experimentrun_pk
     )
@@ -54,16 +54,14 @@ def fetch_washes(client: SlimsClient, experimentrun_pk: int) -> List[SlimsWash]:
                         else None
                     ),
                 )
-                for reagent in (
-                    client.fetch_models(SlimsReagentContent, pk=wash.reagent_pk)
-                    if wash.reagent_pk
-                    else []
-                )
+                for reagent_pk in (wash.reagent_pk or [])
+                for reagent in client.fetch_models(SlimsReagentContent, pk=reagent_pk)
             ],
         )
         for wash in wash_run_steps
     ]
     return washes
+
 
 
 def fetch_histology_procedures(

--- a/src/aind_slims_api/operations/histology_procedures.py
+++ b/src/aind_slims_api/operations/histology_procedures.py
@@ -63,7 +63,6 @@ def fetch_washes(client: SlimsClient, experimentrun_pk: int) -> List[SlimsWash]:
     return washes
 
 
-
 def fetch_histology_procedures(
     client: SlimsClient, specimen_id: str
 ) -> List[SPIMHistologyExpBlock]:

--- a/tests/test_operations/test_histology_procedures.py
+++ b/tests/test_operations/test_histology_procedures.py
@@ -81,8 +81,8 @@ class TestHistologyProcedures(unittest.TestCase):
         self.client.fetch_model.assert_any_call(SlimsReagentDetailsRdrc, pk=10)
         self.client.fetch_model.assert_any_call(SlimsSource, pk=456)
         mock_slims_reagent.assert_called_with(
-            reagent_content=self.example_reagent_content,
-            reagent_details=self.example_reagent_details,
+            content=self.example_reagent_content,
+            details=self.example_reagent_details,
             source=self.example_reagent_source,
         )
         mock_slims_wash.assert_called_with(
@@ -106,8 +106,8 @@ class TestHistologyProcedures(unittest.TestCase):
         self.client.fetch_model.assert_any_call(SlimsReagentDetailsRdrc, pk=10)
         self.client.fetch_model.assert_any_call(SlimsSource, pk=456)
         mock_slims_reagent.assert_called_with(
-            reagent_content=self.example_reagent_content,
-            reagent_details=self.example_reagent_details,
+            content=self.example_reagent_content,
+            details=self.example_reagent_details,
             source=self.example_reagent_source,
         )
         self.assertEqual(len(reagents), 1)

--- a/tests/test_operations/test_histology_procedures.py
+++ b/tests/test_operations/test_histology_procedures.py
@@ -16,15 +16,16 @@ from aind_slims_api.models.experiment_run_step import (
 from aind_slims_api.models.histology import (
     SlimsProtocolSOP,
     SlimsReagentContent,
+    SlimsReagentDetailsRdrc,
     SlimsSampleContent,
-    SlimsSource, SlimsReagentDetailsRdrc,
+    SlimsSource,
 )
 from aind_slims_api.operations.histology_procedures import (
-    SlimsWash,
     SlimsReagent,
+    SlimsWash,
     fetch_histology_procedures,
+    fetch_reagents,
     fetch_washes,
-    fetch_reagents
 )
 
 RESOURCES_DIR = Path(os.path.dirname(os.path.realpath(__file__))) / ".." / "resources"
@@ -162,7 +163,7 @@ class TestHistologyProcedures(unittest.TestCase):
                     SlimsReagent(
                         content=self.example_reagent_content,
                         source=self.example_reagent_source,
-                        details=self.example_reagent_details
+                        details=self.example_reagent_details,
                     )
                 ],
             )

--- a/tests/test_operations/test_histology_procedures.py
+++ b/tests/test_operations/test_histology_procedures.py
@@ -51,7 +51,7 @@ class TestHistologyProcedures(unittest.TestCase):
             name="AA Opto Electronics",
         )
         example_wash_run_step = SlimsWashRunStep(
-            reagent_pk=123,
+            reagent_pk=[123],
             experimentrun_pk=789,
             wash_name="Wash 1",
             spim_wash_type="Passive Delipidation",
@@ -114,7 +114,7 @@ class TestHistologyProcedures(unittest.TestCase):
         mock_fetch_washes.side_effect = lambda c, experimentrun_pk: [
             SlimsWash(
                 wash_step=SlimsWashRunStep(
-                    reagent_pk=123,
+                    reagent_pk=[123],
                     experimentrun_pk=experimentrun_pk,
                     name=f"Wash {experimentrun_pk}",
                     spim_wash_type="Passive Delipidation",

--- a/tests/test_operations/test_histology_procedures.py
+++ b/tests/test_operations/test_histology_procedures.py
@@ -17,12 +17,14 @@ from aind_slims_api.models.histology import (
     SlimsProtocolSOP,
     SlimsReagentContent,
     SlimsSampleContent,
-    SlimsSource,
+    SlimsSource, SlimsReagentDetailsRdrc,
 )
 from aind_slims_api.operations.histology_procedures import (
     SlimsWash,
+    SlimsReagent,
     fetch_histology_procedures,
     fetch_washes,
+    fetch_reagents
 )
 
 RESOURCES_DIR = Path(os.path.dirname(os.path.realpath(__file__))) / ".." / "resources"
@@ -35,43 +37,80 @@ class TestHistologyProcedures(unittest.TestCase):
     def setUp(cls, mock_client):
         """setup test class"""
         cls.client = mock_client()
-
-    @patch("aind_slims_api.operations.histology_procedures.SlimsWash")
-    def test_fetch_washes(self, mock_slims_wash):
-        """Tests washes are fetched successfully"""
-        example_reagent_content = SlimsReagentContent(
+        cls.example_reagent_content = SlimsReagentContent(
             pk=123,
             source_pk=456,
             lot_number="EI60",
-            reagent_name="rgnt0000000",
             barcode="0000000",
+            reagent_ref_pk=10,
         )
-        example_source = SlimsSource(
+        cls.example_reagent_details = SlimsReagentDetailsRdrc(
+            pk=10,
+            manufacturer_pk=456,
+            name="Shield On",
+        )
+        cls.example_reagent_source = SlimsSource(
             pk=456,
             name="AA Opto Electronics",
         )
-        example_wash_run_step = SlimsWashRunStep(
+        cls.example_wash_run_step = SlimsWashRunStep(
             reagent_pk=[123],
             experimentrun_pk=789,
             wash_name="Wash 1",
             spim_wash_type="Passive Delipidation",
         )
+
+    @patch("aind_slims_api.operations.histology_procedures.SlimsReagent")
+    @patch("aind_slims_api.operations.histology_procedures.SlimsWash")
+    def test_fetch_washes(self, mock_slims_wash, mock_slims_reagent):
+        """Tests washes are fetched successfully."""
         self.client.fetch_models.side_effect = lambda model, **kwargs: (
-            [example_reagent_content]
-            if model == SlimsReagentContent
-            else [example_wash_run_step] if model == SlimsWashRunStep else []
+            [self.example_wash_run_step] if model == SlimsWashRunStep else []
         )
-        self.client.fetch_model.return_value = example_source
+        self.client.fetch_model.side_effect = lambda model, **kwargs: {
+            SlimsReagentContent: self.example_reagent_content,
+            SlimsReagentDetailsRdrc: self.example_reagent_details,
+            SlimsSource: self.example_reagent_source,
+        }.get(model)
 
         washes = fetch_washes(self.client, experimentrun_pk=789)
+
         self.client.fetch_models.assert_any_call(SlimsWashRunStep, experimentrun_pk=789)
-        self.client.fetch_models.assert_any_call(SlimsReagentContent, pk=123)
-        self.client.fetch_model.assert_called_with(SlimsSource, pk=456)
+        self.client.fetch_model.assert_any_call(SlimsReagentContent, pk=123)
+        self.client.fetch_model.assert_any_call(SlimsReagentDetailsRdrc, pk=10)
+        self.client.fetch_model.assert_any_call(SlimsSource, pk=456)
+        mock_slims_reagent.assert_called_with(
+            reagent_content=self.example_reagent_content,
+            reagent_details=self.example_reagent_details,
+            source=self.example_reagent_source,
+        )
         mock_slims_wash.assert_called_with(
-            wash_step=example_wash_run_step,
-            reagents=[(example_reagent_content, example_source)],
+            wash_step=self.example_wash_run_step,
+            reagents=[mock_slims_reagent.return_value],
         )
         self.assertEqual(len(washes), 1)
+
+    @patch("aind_slims_api.operations.histology_procedures.SlimsReagent")
+    def test_fetch_reagents(self, mock_slims_reagent):
+        """Tests reagents are fetched successfully."""
+        self.client.fetch_model.side_effect = lambda model, **kwargs: {
+            SlimsReagentContent: self.example_reagent_content,
+            SlimsReagentDetailsRdrc: self.example_reagent_details,
+            SlimsSource: self.example_reagent_source,
+        }.get(model)
+
+        reagents = fetch_reagents(self.client, reagent_pks=[123])
+
+        self.client.fetch_model.assert_any_call(SlimsReagentContent, pk=123)
+        self.client.fetch_model.assert_any_call(SlimsReagentDetailsRdrc, pk=10)
+        self.client.fetch_model.assert_any_call(SlimsSource, pk=456)
+        mock_slims_reagent.assert_called_with(
+            reagent_content=self.example_reagent_content,
+            reagent_details=self.example_reagent_details,
+            source=self.example_reagent_source,
+        )
+        self.assertEqual(len(reagents), 1)
+        self.assertEqual(reagents[0], mock_slims_reagent.return_value)
 
     @patch("aind_slims_api.operations.histology_procedures.fetch_washes")
     def test_fetch_histology_procedures(self, mock_fetch_washes):
@@ -120,15 +159,10 @@ class TestHistologyProcedures(unittest.TestCase):
                     spim_wash_type="Passive Delipidation",
                 ),
                 reagents=[
-                    (
-                        SlimsReagentContent(
-                            pk=123,
-                            source_pk=456,
-                            lot_number="EI60",
-                            reagent_name="rgnt0000000",
-                            barcode="0000000",
-                        ),
-                        SlimsSource(pk=456, name="AA Opto Electronics"),
+                    SlimsReagent(
+                        content=self.example_reagent_content,
+                        source=self.example_reagent_source,
+                        details=self.example_reagent_details
                     )
                 ],
             )
@@ -149,15 +183,18 @@ class TestHistologyProcedures(unittest.TestCase):
                 self.assertIsNotNone(wash.wash_step)
                 self.assertEqual(wash.wash_step.spim_wash_type, "Passive Delipidation")
                 self.assertGreater(len(wash.reagents), 0)
-                for reagent, source in wash.reagents:
-                    self.assertIsInstance(reagent, SlimsReagentContent)
-                    self.assertIsInstance(source, SlimsSource)
+                for reagent in wash.reagents:
+                    self.assertIsInstance(reagent, SlimsReagent)
+                    self.assertIsInstance(reagent.content, SlimsReagentContent)
+                    self.assertIsInstance(reagent.source, SlimsSource)
+                    self.assertIsInstance(reagent.details, SlimsReagentDetailsRdrc)
         # Check attributes of first wash
         first_wash = result[0].washes[0]
         self.assertEqual(first_wash.wash_step.name, "Wash 789")
         self.assertEqual(first_wash.wash_step.experimentrun_pk, 789)
-        self.assertEqual(first_wash.reagents[0][0].reagent_name, "rgnt0000000")
-        self.assertEqual(first_wash.reagents[0][1].name, "AA Opto Electronics")
+        self.assertEqual(first_wash.reagents[0].content.lot_number, "EI60")
+        self.assertEqual(first_wash.reagents[0].source.name, "AA Opto Electronics")
+        self.assertEqual(first_wash.reagents[0].details.name, "Shield On")
 
     def test_fetch_histology_procedures_handles_exception(self):
         """Tests that exception is handled as expected"""


### PR DESCRIPTION
closes #57 

This PR: 
- removes deprecated fields from reagent content model
- adds model for reagent details in reference data record table
- given a reagent pk in wash -> reagent content -> reagent reference data record -> source 
- groups all related reagent information together