### PR TITLE
Revert "updates mouse model for mouse offset (#65)"

### DIFF
--- a/src/aind_slims_api/models/mouse.py
+++ b/src/aind_slims_api/models/mouse.py
@@ -23,24 +23,6 @@ class SlimsMouseContent(SlimsBaseModel):
     >>> mouse = client.fetch_model(SlimsMouseContent, barcode="00000000")
     """
 
-    x_offset: Optional[float] = Field(
-        ...,
-        serialization_alias="cntn_cf_mouseXOffset",
-        validation_alias="cntn_cf_mouseXOffset",
-    )
-
-    y_offset: Optional[float] = Field(
-        ...,
-        serialization_alias="cntn_cf_mouseYOffset",
-        validation_alias="cntn_cf_mouseYOffset",
-    )
-
-    z_offset: Optional[float] = Field(
-        ...,
-        serialization_alias="cntn_cf_mouseZOffset",
-        validation_alias="cntn_cf_mouseZOffset",
-    )
-
     baseline_weight_g: Annotated[float | None, UnitSpec("g")] = Field(
         ...,
         serialization_alias="cntn_cf_baselineWeight",

--- a/tests/resources/example_fetch_mouse_response.json
+++ b/tests/resources/example_fetch_mouse_response.json
@@ -415,33 +415,6 @@
             "editable": true
          },
          {
-            "datatype": "FLOAT",
-            "editable": true,
-            "hidden": false,
-            "name": "cntn_cf_mouseXOffset",
-            "position": 38,
-            "title": "Mouse X offset",
-            "value": 9.0
-         },
-        {
-           "datatype": "FLOAT",
-           "editable": true,
-           "hidden": false,
-           "name": "cntn_cf_mouseYOffset",
-           "position": 39,
-           "title": "Mouse Y offset",
-           "value": null
-        },
-        {
-          "datatype": "FLOAT",
-           "editable": true,
-           "hidden": false,
-           "name": "cntn_cf_mouseZOffset",
-           "position": 40,
-           "title": "Mouse Z offset",
-           "value": null
-        },
-         {
             "datatype": "FOREIGN_KEY",
             "name": "cntn_fk_product_strain",
             "title": "Product (filtering without version)",

--- a/tests/test_behavior_session.py
+++ b/tests/test_behavior_session.py
@@ -72,10 +72,6 @@ class TestBehaviorSession(unittest.TestCase):
             cntn_cf_waterRestricted=False,
             cntn_cf_scientificPointOfContact=None,
             cntn_cf_baselineWeight=None,
-            cntn_cf_mouseXOffset=None,
-            cntn_cf_mouseYOffset=None,
-            cntn_cf_mouseZOffset=None
-
         )
         cls.example_behavior_sessions = [
             SlimsBehaviorSession(


### PR DESCRIPTION
This reverts commit 57bf40282f69ef60b80069902c418831eba8e2c4.

Need to revert since offset for mouse model is only in sandbox repo not main. This is causing errors in dynamic foraging gui 